### PR TITLE
Add behavior to normalize filename in header

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -182,7 +182,9 @@ const init = (providerConfig) => {
             typeof config.metadata === 'function'
               ? config.metadata(file)
               : {
-                  contentDisposition: `inline; filename="${file.name}"`,
+                  contentDisposition: `inline; filename="${file.name
+                    .normalize('NFD')
+                    .replace(/[\u0300-\u036f]/g, '')}"`,
                   cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
                 },
         };

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -174,7 +174,7 @@ const init = (providerConfig) => {
           console.info('File already exists. Try to remove it.');
           await this.delete(file);
         }
-        const asciiFileName = file.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        const asciiFileName = file.name.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
         const fileAttributes = {
           contentType:
             typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -174,6 +174,7 @@ const init = (providerConfig) => {
           console.info('File already exists. Try to remove it.');
           await this.delete(file);
         }
+        const asciiFileName = file.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
         const fileAttributes = {
           contentType:
             typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,
@@ -182,9 +183,7 @@ const init = (providerConfig) => {
             typeof config.metadata === 'function'
               ? config.metadata(file)
               : {
-                  contentDisposition: `inline; filename="${file.name
-                    .normalize('NFD')
-                    .replace(/[\u0300-\u036f]/g, '')}"`,
+                  contentDisposition: `inline; filename="${asciiFileName}"`,
                   cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
                 },
         };


### PR DESCRIPTION
These changes closes #135

I've added a regex to replace any diacritics to their closest ascii character:

| diacritics                      | ascii                            |
|-------------------------------|------------------------------|
| á                                  | a                                 |
| fõô bàr                         | foo bar                        |
| défìñitlỹ-nôń-ásçìĩ.pñg | definitly-non-ascii.png |

---

I'm not sure about the best practices for testing this functionality. Any help is very welcome.