### PR TITLE
fix: Cannot read property 'replace' of undefined

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -249,6 +249,11 @@ const init = (providerConfig) => {
       }
     },
     async delete(file) {
+       if (!file.url) {
+        console.warn('Remote file was not found, you may have to delete manually.');
+        return;
+      }
+
       const fileName = file.url.replace(`${baseUrl}/`, '');
       const bucket = GCS.bucket(config.bucketName);
       try {


### PR DESCRIPTION
Hello,

sometimes I got error when replacing file:
```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
TypeError: Cannot read property 'replace' of undefined
    at Object.delete (/srv/app/node_modules/strapi-provider-upload-google-cloud-storage/lib/provider.js:203:33)
    at Object.upload (/srv/app/node_modules/strapi-provider-upload-google-cloud-storage/lib/provider.js:175:28)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Object.upload (/srv/app/node_modules/@strapi/plugin-upload/server/services/provider.js:14:7)
```

I can't clearly describe the reproduction steps, but this fixes the bug.
