### PR TITLE
Add node 18 and npm 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "prettier": "^2.5.0"
   },
   "engines": {
-    "node": "16",
-    "npm": "8"
+    "node": "^16 || ^18",
+    "npm": ">=8"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
Duplicating the work from @jpcmf and @Lith in https://github.com/strapi-community/strapi-provider-upload-google-cloud-storage/pull/159 with a slight modification and a signed commit that should be easier to merge. Also need this fairly urgently for a project.

Thanks

Signed-off-by: Patrick Heneise <patrick@zentered.co>