### PR TITLE
Support async generateUploadFileName method

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ When no function is provided, the [default algorithm](lib/provider.js) is used.
 Example:
 
 ```js
-  generateUploadFileName: (file) => {
-    const hash = ...; // Some hashing function, for example MD-5
+  generateUploadFileName: async (file) => {
+    const hash = await ...; // Some hashing function, for example MD-5
     const extension = file.ext.toLowerCase().substring(1);
     return `${extension}/${slugify(path.parse(file.name).name)}-${hash}.${extension}`;
   },

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -163,7 +163,7 @@ const init = (providerConfig) => {
       try {
         const fullFileName =
           typeof config.generateUploadFileName === 'function'
-            ? config.generateUploadFileName(file)
+            ? await config.generateUploadFileName(file)
             : generateUploadFileName(basePath, file);
         if (!config.skipCheckBucket) {
           await checkBucket(GCS, config.bucketName);
@@ -205,7 +205,7 @@ const init = (providerConfig) => {
       try {
         const fullFileName =
           typeof config.generateUploadFileName === 'function'
-            ? config.generateUploadFileName(file)
+            ? await config.generateUploadFileName(file)
             : generateUploadFileName(basePath, file);
         if (!config.skipCheckBucket) {
           await checkBucket(GCS, config.bucketName);
@@ -244,7 +244,7 @@ const init = (providerConfig) => {
       }
     },
     async delete(file) {
-       if (!file.url) {
+      if (!file.url) {
         console.warn('Remote file was not found, you may have to delete manually.');
         return;
       }

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -546,7 +546,7 @@ describe('/lib/provider.js', () => {
             mockRequire.stop('@google-cloud/storage');
           });
 
-          it('must save file with custom file name generator', async () => {
+          it('must save file with custom (async) file name generator', async () => {
             const saveExpectedArgs = [
               'file buffer information',
               {
@@ -582,8 +582,10 @@ describe('/lib/provider.js', () => {
                 private_key: 'a random key',
               },
               bucketName: 'any bucket',
-              generateUploadFileName: (file) => {
-                const hash = 'da2f32c2de25f0360d6a5e129dcf9cbc';
+              generateUploadFileName: async (file) => {
+                const hash = await new Promise((resolve) =>
+                  setTimeout(resolve('da2f32c2de25f0360d6a5e129dcf9cbc'), 0)
+                );
                 const extension = file.ext.toLowerCase().substring(1);
                 return `${extension}/${slugify(path.parse(file.name).name)}-${hash}.${extension}`;
               },


### PR DESCRIPTION
Which is required such that the getStream method on uploaded files (in Strapi 4) can be used.

### Strapi 3

In Strapi 3 we could use the exposed file buffer to compute a (for example) md5 hash of the uploaded file:

```js
      generateUploadFileName: (file) => {
        const extension = file.ext.toLowerCase();
        const uploadPath = ...;
        const hash = md5(file.buffer);
        const fileNameWithoutExtension = slugify(path.parse(file.name).name);
        return `${uploadPath}/${fileNameWithoutExtension}-${hash}${extension}`;
      },
```

### Strapi 4

In Strapi 4 the `buffer` does not seem to be exposed anymore. Instead we find a `getStream()` method which can be used to get a [ReadStream](https://nodejs.org/api/fs.html#fscreatereadstreampath-options) of the file ([source](https://github.com/strapi/strapi/blob/1b6a6926e6e515541b9b5e79544d70549b1b62d1/packages/core/upload/server/services/upload.js#L130)). This can be used to computed a md5 hash, but this requires generateFileName to be async-compatible.

```ts
        generateUploadFileName: async (file: File) => {
          const extension = file.ext.toLowerCase();
          const uploadPath = ...;
          const hash = await md5(file.getStream());
          const fileNameWithoutExtension = slugify(path.parse(file.name).name);
          return `${uploadPath}/${fileNameWithoutExtension}-${hash}${extension}`;
        },
```

Sample md5 method for ReadStream:

```ts
function md5(rs: ReadStream): Promise<string> {
  return new Promise((resolve, reject) => {
    const hash = crypto.createHash('md5');
    rs.on('error', reject);
    rs.on('data', (chunk: string | Buffer) => hash.update(chunk));
    rs.on('end', () => resolve(hash.digest('hex')));
  });
}
```