### PR TITLE
private assets signing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ module.exports = {
 }
 ```
 
+If you set `publicFiles` to `false`, the assets will be signed on the Content Manager (not the Content API) and the Media Library. Consequently, they will only be visible to users who are authenticated.
+
+You can set the expiry time of the signed URL by setting the `expires` option in the `providerOptions` object. See more in [expires](#expires).
+
 **Example with credentials for outside GCP account**
 
 Edit `./config/plugins.js`
@@ -214,6 +218,15 @@ Number to set the cache-control header for uploaded files.
 Value to define if files are uploaded and stored with gzip compression.
 - Possible values: `true`, `false`, `auto`
 - Default value : `auto`
+- Optional
+
+#### `expires`:
+
+Value to define expiration time for signed URLS. Files are signed when `publicFiles` is set to `false`.
+
+- Possible values: `Date`, `number`, `string`
+- Default value : `900000` (15 minutes)
+- Max value : `604800000` (7 days)
 - Optional
 
 ### `metadata`:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = {
 }
 ```
 
-If you set `publicFiles` to `false`, the assets will be signed on the Content Manager (not the Content API) and the Media Library. Consequently, they will only be visible to users who are authenticated.
+If you set `publicFiles` to `false`, the assets will be signed on the Content Manager (not the Content API). Consequently, they will only be visible to users who are authenticated.
 
 You can set the expiry time of the signed URL by setting the `expires` option in the `providerOptions` object. See more in [expires](#expires).
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -244,7 +244,7 @@ const init = (providerConfig) => {
       }
     },
     async delete(file) {
-       if (!file.url) {
+      if (!file.url) {
         console.warn('Remote file was not found, you may have to delete manually.');
         return;
       }
@@ -261,6 +261,19 @@ const init = (providerConfig) => {
         // based on last code, it will never throw (resolves and rejects)
         // throw error;
       }
+    },
+    isPrivate() {
+      return !config.publicFiles;
+    },
+    async getSignedUrl(file) {
+      const options = {
+        version: 'v4',
+        action: 'read',
+        expires: config.expires || Date.now() + 15 * 60 * 1000, // 15 minutes from now
+      };
+      const fileName = file.url.replace(`${baseUrl}/`, '');
+      const [url] = await GCS.bucket(config.bucketName).file(fileName).getSignedUrl(options);
+      return { url };
     },
   };
 };

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -361,7 +361,7 @@ describe('/lib/provider.js', () => {
       }
     });
 
-    it('must return an object with upload and delete methods', () => {
+    it('must return an object with upload, delete, isPrivate and getSignedUrl methods', () => {
       const config = {
         serviceAccount: {
           project_id: '123',
@@ -377,6 +377,10 @@ describe('/lib/provider.js', () => {
       assert.equal(typeof result.upload, 'function');
       assert.ok(Object.keys(result).includes('delete'));
       assert.equal(typeof result.delete, 'function');
+      assert.ok(Object.keys(result).includes('isPrivate'));
+      assert.equal(typeof result.isPrivate, 'function');
+      assert.ok(Object.keys(result).includes('getSignedUrl'));
+      assert.equal(typeof result.getSignedUrl, 'function');
     });
 
     it('must instanciate google cloud storage with right configurations', () => {


### PR DESCRIPTION
Hello! First I do want to say that this is an awesome plugin, and THANK YOU for maintaining it. 

In Strapi we are working on supporting private configurations for providers https://github.com/strapi/strapi/pull/15773 . Meaning that files that are uploaded to be private can be visualised in the Content Manager

This work will be released in 4.9.0.

### What does it do?

This is the work of @jihyukbae, he was trying to test the feature using this specific provider so all props to him! I am just creating this PR and asking for feedback.

This work adds support to visualise gcp private assets in the Content Manager.

We would appreciate if some of you could review this work and express your opinions / suggestions :) This feedback can help reshape and improve the current implementation of file signing.

### Why is it needed?
So users uploading private assets can display those in the content manager.

### How to test it?

- Use 4.9.0 version of strapi.
- Set the `publicFiles` config to false
- Upload a new image in the Media Library. 
- That file url should be signed and you should be able to display that asset.
