### PR TITLE
FIX: Always setting public files to true

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -26,6 +26,28 @@ const get = (obj, path, defaultValue = undefined) => {
 };
 
 /**
+ * Sets a configuration field value.
+ *
+ * @param {*} fieldValue - The value to validate.
+ * @param {*} defaultValue - The default value to return if the field is not provided or is invalid.
+ * @returns {*} The validated field value or the default value.
+ * @throws {Error} If the default value is undefined or the field value is undefined.
+ */
+const setConfigField = (fieldValue, defaultValue) => {
+  if (typeof defaultValue === 'undefined') throw new Error('Default value is required!');
+  if (typeof fieldValue === 'undefined') return defaultValue;
+  switch (typeof fieldValue) {
+    case 'boolean':
+      return fieldValue;
+    case 'string':
+      if (['true', 'false'].includes(fieldValue)) return fieldValue === 'true';
+      throw new Error(`Invalid boolean value for ${fieldValue}!`);
+    default:
+      return defaultValue;
+  }
+}
+
+/**
  * Check validity of Service Account configuration
  * @param config
  * @returns {{private_key}|{client_email}|{project_id}|any}
@@ -43,9 +65,9 @@ const checkServiceAccount = (config = {}) => {
   }
 
   /** Check or set default boolean optional variable */
-  config.publicFiles = eval(config.publicFiles) || true; // default value
-  config.uniform = eval(config.uniform) || false; // default value
-  config.skipCheckBucket = eval(config.skipCheckBucket) || false; // default value
+  config.publicFiles = setConfigField(config.publicFiles, true); // default value
+  config.uniform = setConfigField(config.uniform, false); // default value
+  config.skipCheckBucket = setConfigField(config.skipCheckBucket, false); // default value
 
   let serviceAccount;
   if (config.serviceAccount) {


### PR DESCRIPTION

## Problem
There is currently a bug in the code especially on `line 46` where publicFIles is always true, e.g
```ts
config.publicFiles = false || true; // ALWAYS: true
config.publicFiles = true || true; // ALWAYS: true
config.publicFiles = eval('something else') || true; // throws an error and it was not handled
```
## Solution
Make sure we do proper checking with the new util function `setConfigField`  in case if the config value is string, undefined or an actual boolean. I didn't see a reason to really add tests for this, but if you guys want to do this, I can take care of it.