### PR TITLE
Fix: streaming debug log was broken

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -256,8 +256,8 @@ const init = (providerConfig) => {
           await this.delete(file);
         }
         await pipeline(file.stream, bucketFile.createWriteStream(fileAttributes));
-        console.debug(`File successfully uploaded to ${file.url}`);
         file.url = `${baseUrl}/${fullFileName}`;
+        console.debug(`File successfully uploaded (streaming) to ${file.url}`);
       } catch (error) {
         // Re-throw so that the upload operation will fail
         // and error will surface to the user in the Strapi admin front-end


### PR DESCRIPTION
`${file.url}` was being logged before it was set.