### PR TITLE
Fix: move file.url creation above log so it is defined

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -256,8 +256,8 @@ const init = (providerConfig) => {
           await this.delete(file);
         }
         await pipeline(file.stream, bucketFile.createWriteStream(fileAttributes));
-        console.debug(`File successfully uploaded to ${file.url}`);
         file.url = `${baseUrl}/${fullFileName}`;
+        console.debug(`File successfully uploaded to ${file.url}`);
       } catch (error) {
         // Re-throw so that the upload operation will fail
         // and error will surface to the user in the Strapi admin front-end


### PR DESCRIPTION
This change simply moves the creation of `file.url` up one line so that its value is set before an attempt to log it, which was otherwise resulting in the bug: `File successfully uploaded to undefined`